### PR TITLE
:wrench: Exclude .jekyll-cache dir from being watched

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -91,6 +91,7 @@ exclude:
   - ".csscomb.json"
   - ".ruby-version"
   - ".cache"
+  - ".jekyll-cache"
   - "node_modules"
   - "package.json"
   - "scripts"


### PR DESCRIPTION
So that Jekyll doesn't log about changed files in `jekyll-cache` while regenerating a site during `jekyll serve` or `jekyll build --watch`